### PR TITLE
feat: import.meta.hot support

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -144,3 +144,14 @@ export async function resolveDefault(importPath: string, parentURL: URL | string
 
   return moduleExports.default
 }
+
+/**
+ * - if `import.meta.hot` is true then the callback will always be evaluated
+ * - otherwise, the callback will be evaluated only when the cached value is missing
+ */
+export async function resolveCachedWithHotFallback(cachedValue: any, callback: () => any) {
+  // @ts-expect-error import.meta.hot is not defined in this context.
+  if (import.meta.hot) return await callback()
+
+  return cachedValue || (await callback())
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -144,14 +144,3 @@ export async function resolveDefault(importPath: string, parentURL: URL | string
 
   return moduleExports.default
 }
-
-/**
- * - if `import.meta.hot` is true then the callback will always be evaluated
- * - otherwise, the callback will be evaluated only when the cached value is missing
- */
-export async function resolveCachedWithHotFallback(cachedValue: any, callback: () => any) {
-  // @ts-expect-error import.meta.hot is not defined in this context.
-  if (import.meta.hot) return await callback()
-
-  return cachedValue || (await callback())
-}

--- a/src/module_expression.ts
+++ b/src/module_expression.ts
@@ -8,9 +8,9 @@
  */
 
 import { Container } from './container.js'
-import { resolveCachedWithHotFallback, resolveDefault } from './helpers.js'
 import { ContainerResolver } from './resolver.js'
 import type { ModuleHandler, ModuleCallable } from './types.js'
+import { resolveCachedWithHotFallback, resolveDefault } from './helpers.js'
 
 /**
  * The moduleExpression module works around a very specific pattern we use

--- a/src/module_expression.ts
+++ b/src/module_expression.ts
@@ -8,9 +8,9 @@
  */
 
 import { Container } from './container.js'
+import { resolveDefault } from './helpers.js'
 import { ContainerResolver } from './resolver.js'
 import type { ModuleHandler, ModuleCallable } from './types.js'
-import { resolveCachedWithHotFallback, resolveDefault } from './helpers.js'
 
 /**
  * The moduleExpression module works around a very specific pattern we use
@@ -106,11 +106,9 @@ export function moduleExpression(expression: string, parentURL: URL | string) {
        */
       if (container) {
         return async function (...args: Args) {
-          defaultExport = await resolveCachedWithHotFallback(
-            defaultExport,
-            async () => await resolveDefault(importPath, parentURL)
-          )
-
+          if (!defaultExport || 'hot' in import.meta) {
+            defaultExport = await resolveDefault(importPath, parentURL)
+          }
           return container.call(await container.make(defaultExport), method, args)
         } as ModuleCallable<T, Args>
       }
@@ -119,11 +117,9 @@ export function moduleExpression(expression: string, parentURL: URL | string) {
        * Otherwise the return function asks for the resolver or container
        */
       return async function (resolver: ContainerResolver<any> | Container<any>, ...args: Args) {
-        defaultExport = await resolveCachedWithHotFallback(
-          defaultExport,
-          async () => await resolveDefault(importPath, parentURL)
-        )
-
+        if (!defaultExport || 'hot' in import.meta) {
+          defaultExport = await resolveDefault(importPath, parentURL)
+        }
         return resolver.call(await resolver.make(defaultExport), method, args)
       } as ModuleCallable<T, Args>
     },
@@ -167,10 +163,9 @@ export function moduleExpression(expression: string, parentURL: URL | string) {
       if (container) {
         return {
           async handle(...args: Args) {
-            defaultExport = await resolveCachedWithHotFallback(
-              defaultExport,
-              async () => await resolveDefault(importPath, parentURL)
-            )
+            if (!defaultExport || 'hot' in import.meta) {
+              defaultExport = await resolveDefault(importPath, parentURL)
+            }
             return container.call(await container.make(defaultExport), method, args)
           },
         } as ModuleHandler<T, Args>
@@ -178,10 +173,9 @@ export function moduleExpression(expression: string, parentURL: URL | string) {
 
       return {
         async handle(resolver: ContainerResolver<any> | Container<any>, ...args: Args) {
-          defaultExport = await resolveCachedWithHotFallback(
-            defaultExport,
-            async () => await resolveDefault(importPath, parentURL)
-          )
+          if (!defaultExport || 'hot' in import.meta) {
+            defaultExport = await resolveDefault(importPath, parentURL)
+          }
           return resolver.call(await resolver.make(defaultExport), method, args)
         },
       } as ModuleHandler<T, Args>

--- a/src/module_importer.ts
+++ b/src/module_importer.ts
@@ -11,7 +11,6 @@ import { importDefault } from '@poppinss/utils'
 
 import { Container } from './container.js'
 import { ContainerResolver } from './resolver.js'
-import { resolveCachedWithHotFallback } from './helpers.js'
 import type { ModuleHandler, ModuleCallable, Constructor } from './types.js'
 
 /**
@@ -86,10 +85,9 @@ export function moduleImporter(
        */
       if (container) {
         return async function (...args: Args) {
-          defaultExport = await resolveCachedWithHotFallback(
-            defaultExport,
-            async () => await importDefault(importFn)
-          )
+          if (!defaultExport || 'hot' in import.meta) {
+            defaultExport = await importDefault(importFn)
+          }
           return container.call(await container.make(defaultExport), method, args)
         } as ModuleCallable<T, Args>
       }
@@ -98,10 +96,9 @@ export function moduleImporter(
        * Otherwise the return function asks for the resolver or container
        */
       return async function (resolver: ContainerResolver<any> | Container<any>, ...args: Args) {
-        defaultExport = await resolveCachedWithHotFallback(
-          defaultExport,
-          async () => await importDefault(importFn)
-        )
+        if (!defaultExport || 'hot' in import.meta) {
+          defaultExport = await importDefault(importFn)
+        }
         return resolver.call(await resolver.make(defaultExport), method, args)
       } as ModuleCallable<T, Args>
     },
@@ -145,10 +142,9 @@ export function moduleImporter(
         return {
           name: importFn.name,
           async handle(...args: Args) {
-            defaultExport = await resolveCachedWithHotFallback(
-              defaultExport,
-              async () => await importDefault(importFn)
-            )
+            if (!defaultExport || 'hot' in import.meta) {
+              defaultExport = await importDefault(importFn)
+            }
             return container.call(await container.make(defaultExport), method, args)
           },
         } as ModuleHandler<T, Args>
@@ -157,10 +153,9 @@ export function moduleImporter(
       return {
         name: importFn.name,
         async handle(resolver: ContainerResolver<any> | Container<any>, ...args: Args) {
-          defaultExport = await resolveCachedWithHotFallback(
-            defaultExport,
-            async () => await importDefault(importFn)
-          )
+          if (!defaultExport || 'hot' in import.meta) {
+            defaultExport = await importDefault(importFn)
+          }
           return resolver.call(await resolver.make(defaultExport), method, args)
         },
       } as ModuleHandler<T, Args>

--- a/src/module_importer.ts
+++ b/src/module_importer.ts
@@ -11,6 +11,7 @@ import { importDefault } from '@poppinss/utils'
 
 import { Container } from './container.js'
 import { ContainerResolver } from './resolver.js'
+import { resolveCachedWithHotFallback } from './helpers.js'
 import type { ModuleHandler, ModuleCallable, Constructor } from './types.js'
 
 /**
@@ -85,7 +86,10 @@ export function moduleImporter(
        */
       if (container) {
         return async function (...args: Args) {
-          defaultExport = defaultExport || (await importDefault(importFn))
+          defaultExport = await resolveCachedWithHotFallback(
+            defaultExport,
+            async () => await importDefault(importFn)
+          )
           return container.call(await container.make(defaultExport), method, args)
         } as ModuleCallable<T, Args>
       }
@@ -94,7 +98,10 @@ export function moduleImporter(
        * Otherwise the return function asks for the resolver or container
        */
       return async function (resolver: ContainerResolver<any> | Container<any>, ...args: Args) {
-        defaultExport = defaultExport || (await importDefault(importFn))
+        defaultExport = await resolveCachedWithHotFallback(
+          defaultExport,
+          async () => await importDefault(importFn)
+        )
         return resolver.call(await resolver.make(defaultExport), method, args)
       } as ModuleCallable<T, Args>
     },
@@ -138,7 +145,10 @@ export function moduleImporter(
         return {
           name: importFn.name,
           async handle(...args: Args) {
-            defaultExport = defaultExport || (await importDefault(importFn))
+            defaultExport = await resolveCachedWithHotFallback(
+              defaultExport,
+              async () => await importDefault(importFn)
+            )
             return container.call(await container.make(defaultExport), method, args)
           },
         } as ModuleHandler<T, Args>
@@ -147,7 +157,10 @@ export function moduleImporter(
       return {
         name: importFn.name,
         async handle(resolver: ContainerResolver<any> | Container<any>, ...args: Args) {
-          defaultExport = defaultExport || (await importDefault(importFn))
+          defaultExport = await resolveCachedWithHotFallback(
+            defaultExport,
+            async () => await importDefault(importFn)
+          )
           return resolver.call(await resolver.make(defaultExport), method, args)
         },
       } as ModuleHandler<T, Args>


### PR DESCRIPTION
Added this for Hot-hook/HMR support : https://github.com/Julien-R44/hot-hook

Basically, we keep the cache system when `import.meta.hot` is not defined. If it is defined, then we always re-evaluate callbacks.

There's still a slight difference in the benchmark ( ~10% ), but I think it's negligible.

If you think this is important, we can optimize that, but the code will be more verbose: we would remove the `resolveCachedWithHotFallback` function and inline the same code. This would avoid calling an async function even when the cache is used. 

Before benchmark
![Pasted image 20240331130349](https://github.com/adonisjs/fold/assets/8337858/00415b0a-1411-4d63-992a-f729b82cf1ee)

After benchmark : 
![image](https://github.com/adonisjs/fold/assets/8337858/65ded415-bf9e-403d-b211-9fc9109abfd9)

---

I didn't add tests for that. I think we can do without it because it's a bit boring to test (we have to setup a loader hook node + spawn processes) and the code is super basic. But same, lemme know if it seems important to you to have
