### PR TITLE
fix: isClass for minified class expression

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ import { Deferred } from './deferred_promise.ts'
  * functions are not considered as class constructor.
  */
 export function isClass<T>(value: unknown): value is Constructor<T> {
-  return typeof value === 'function' && value.toString().startsWith('class ')
+  return typeof value === 'function' && /^class(\s|{)/.test(value.toString())
 }
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Related change in https://github.com/sindresorhus/is/pull/217, several of the Adonis packages seem to be using.

I was experimenting recently with bundling the Adonis codebase via ESBuild, and everything seemed to work. However when I minified the code, it broke in a strange way. It seemed to be due to the minification creating a class expression with `class{}`, which `isClass` did not evaluate true for.

It seems the other packages are now using `@sindresorhus/is`, however this one still has the standalone `isClass` helper, so this is just adding my change from that repo here.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
