### PR TITLE
fix: wait for hooks when resolving singleton in paralel

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -324,21 +324,21 @@ export class ContainerResolver<KnownBindings extends Record<any, any>> {
      * Followed by the CONTAINER bindings
      */
     if (this.#containerBindings.has(binding)) {
-      const { resolver, isSingleton } = this.#containerBindings.get(binding)!
+      const containerBinding = this.#containerBindings.get(binding)!
       let value
-      let executeHooks = isSingleton ? false : true
+      let executeHooks = true
 
       /**
        * Invoke binding resolver to get the value. In case of singleton,
        * the "enqueue" method returns an object with the value and a
        * boolean telling if a cached value is resolved.
        */
-      if (isSingleton) {
-        const result = await resolver(this, runtimeValues)
+      if (containerBinding.isSingleton) {
+        const result = await containerBinding.resolver(this, runtimeValues)
         value = result.value
         executeHooks = !result.cached
       } else {
-        value = await resolver(this, runtimeValues)
+        value = await containerBinding.resolver(this, runtimeValues)
       }
 
       if (debug.enabled) {
@@ -346,8 +346,22 @@ export class ContainerResolver<KnownBindings extends Record<any, any>> {
       }
 
       if (executeHooks) {
-        await this.#execHooks(binding, value)
+        const hooksPromise = this.#execHooks(binding, value)
+
+        // if singleton, store the hooks promise that will be awaited for subsequent resolutions
+        if (containerBinding.isSingleton) {
+          containerBinding.hooksPromise = hooksPromise.then(() => {
+            delete containerBinding.hooksPromise
+          })
+        }
+
+        await hooksPromise
       }
+
+      if (containerBinding.isSingleton) {
+        await containerBinding.hooksPromise
+      }
+
       this.#emit(binding, value)
 
       return value

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export type Bindings = Map<
         runtimeValues?: any[]
       ) => Promise<{ value: any; cached: boolean }>
       isSingleton: true
+      hooksPromise?: Promise<void>
     }
 >
 

--- a/tests/container/hooks.spec.ts
+++ b/tests/container/hooks.spec.ts
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import * as timers from 'node:timers'
 import { test } from '@japa/runner'
 import { EventEmitter } from 'node:events'
 import { expectTypeOf } from 'expect-type'
@@ -228,5 +229,31 @@ test.group('Container | Hooks', () => {
 
     assert.instanceOf(route, Route)
     assert.equal(route.invocations, 1)
+  })
+
+  test('wait for hook when a singleton is resolved paralely', async ({ assert }) => {
+    const emitter = new EventEmitter()
+    const container = new Container<{ route: Route }>({ emitter })
+    class Route {
+      invocations: number = 0
+    }
+
+    container.singleton('route', () => {
+      return new Route()
+    })
+
+    container.resolving('route', async (route) => {
+      await timers.promises.setTimeout(100)
+
+      route.invocations++
+    })
+
+    await Promise.all(
+      new Array(2).fill(0).map(async () => {
+        const route = await container.make('route')
+
+        assert.equal(route.invocations, 1)
+      })
+    )
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

#66 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #66 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
